### PR TITLE
Feature/tos and user agreement

### DIFF
--- a/cuenca_validations/types/__init__.py
+++ b/cuenca_validations/types/__init__.py
@@ -73,7 +73,6 @@ __all__ = [
     'StrictPositiveInt',
     'StrictTransferRequest',
     'TermsOfService',
-    'TOSAgreement',
     'TOSRequest',
     'TrackDataMethod',
     'TransactionQuery',
@@ -167,7 +166,6 @@ from .identities import (
     KYCFile,
     PhoneNumber,
     Rfc,
-    TOSAgreement,
     VerificationErrors,
 )
 from .queries import (

--- a/cuenca_validations/types/identities.py
+++ b/cuenca_validations/types/identities.py
@@ -12,7 +12,6 @@ from pydantic import (
 from pydantic_extra_types.phone_numbers import PhoneNumber
 
 from .enums import Country, KYCFileType, State, VerificationStatus
-from .general import SerializableIPvAnyAddress
 
 Password = Annotated[
     SecretStr,

--- a/cuenca_validations/types/identities.py
+++ b/cuenca_validations/types/identities.py
@@ -161,18 +161,3 @@ class KYCFile(BaseModel):
             }
         },
     )
-
-
-class TOSAgreement(BaseModel):
-    version: str
-    ip: SerializableIPvAnyAddress
-    location: Optional[str] = None
-    model_config = ConfigDict(
-        json_schema_extra={
-            "example": {
-                "version": "2022-01-01",
-                "ip": "192.168.0.1",
-                "location": "19.427224, -99.168082",
-            }
-        }
-    )

--- a/cuenca_validations/types/requests.py
+++ b/cuenca_validations/types/requests.py
@@ -69,7 +69,6 @@ from .identities import (
     Password,
     PhoneNumber,
     Rfc,
-    TOSAgreement,
 )
 from .morals import (
     AuditDetails,
@@ -397,7 +396,7 @@ class CurpValidationRequest(BaseModel):
 
 class TOSRequest(BaseModel):
     type: TermsOfService
-    version: str
+    tos_id: str
     location: Optional[str] = None
     ip: Optional[SerializableIPvAnyAddress] = None
 
@@ -484,7 +483,6 @@ class UserUpdateRequest(BaseModel):
     signature: Optional[KYCFile] = None
     status: Optional[UserStatus] = None
     terms_of_service: Optional[TOSRequest] = None
-    platform_terms_of_service: Optional[TOSAgreement] = None
     curp_document_uri: Optional[SerializableHttpUrl] = None
 
     @field_validator('beneficiaries')


### PR DESCRIPTION
### Description
This PR updates `TOSRequest`, replacing the `version` field with the `tos_id` field, which represents the ID of the terms and conditions catalog.

Additionally, it removes `TOSAgreement`, as it is no longer needed with the new structure.